### PR TITLE
Primary key to text from tuple

### DIFF
--- a/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/serializer/CustomValueSerializers.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/bridge/serializer/CustomValueSerializers.java
@@ -72,11 +72,9 @@ public class CustomValueSerializers {
     return to;
   }
 
-  public static List<QueryOuterClass.Value> getDocumentIdValue(DocumentId documentId) {
+  public static String getDocumentIdValue(DocumentId documentId) {
     // Temporary implementation until we convert it to Tuple in DB
-    List<QueryOuterClass.Value> tupleValues =
-        List.of(Values.of(documentId.typeId()), Values.of(documentId.asDBKey()));
-    return tupleValues;
+    return documentId.asDBKey();
   }
 
   public static QueryOuterClass.Value getVectorValue(float[] vector) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/ReadOperation.java
@@ -299,10 +299,8 @@ public interface ReadOperation extends Operation {
    * @return
    */
   default DocumentId getDocumentId(QueryOuterClass.Value value) {
-    QueryOuterClass.Collection coll = value.getCollection();
-    int typeId = Values.tinyint(coll.getElements(0));
-    String documentIdAsText = Values.string(coll.getElements(1));
-    return DocumentId.fromDatabase(typeId, documentIdAsText);
+    String documentIdAsText = value.getString();
+    return DocumentId.fromDatabase(1, documentIdAsText);
   }
 
   private String extractPagingStateFromResultSet(QueryOuterClass.ResultSet rSet) {

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperation.java
@@ -153,7 +153,7 @@ public record CreateCollectionOperation(
     if (vectorSearch) {
       String createTableWithVector =
           "CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" ("
-              + "    key                 tuple<tinyint,text>,"
+              + "    key                 text,"
               + "    tx_id               timeuuid, "
               + "    doc_json            text,"
               + "    exist_keys          set<text>,"
@@ -177,7 +177,7 @@ public record CreateCollectionOperation(
     } else {
       String createTable =
           "CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" ("
-              + "    key                 tuple<tinyint,text>,"
+              + "    key                 text,"
               + "    tx_id               timeuuid, "
               + "    doc_json            text,"
               + "    exist_keys          set<text>,"

--- a/src/main/java/io/stargate/sgv2/jsonapi/service/schema/model/JsonapiTableMatcher.java
+++ b/src/main/java/io/stargate/sgv2/jsonapi/service/schema/model/JsonapiTableMatcher.java
@@ -16,7 +16,7 @@ public class JsonapiTableMatcher implements Predicate<Schema.CqlTable> {
   private final Predicate<QueryOuterClass.ColumnSpec> columnsPredicateVector;
 
   public JsonapiTableMatcher() {
-    primaryKeyPredicate = new CqlColumnMatcher.Tuple("key", Basic.TINYINT, Basic.VARCHAR);
+    primaryKeyPredicate = new CqlColumnMatcher.BasicType("key", Basic.VARCHAR);
     columnsPredicate =
         new CqlColumnMatcher.BasicType("tx_id", Basic.TIMEUUID)
             .or(new CqlColumnMatcher.BasicType("doc_json", Basic.VARCHAR))

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/CreateCollectionOperationTest.java
@@ -171,7 +171,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
     List<String> queries = new ArrayList<>();
     String createTable =
         "CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" ("
-            + "    key                 tuple<tinyint,text>,"
+            + "    key                 text,"
             + "    tx_id               timeuuid, "
             + "    doc_json            text,"
             + "    exist_keys          set<text>,"
@@ -186,7 +186,7 @@ public class CreateCollectionOperationTest extends AbstractValidatingStargateBri
 
     String createTableWithVector =
         "CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" ("
-            + "    key                 tuple<tinyint,text>,"
+            + "    key                 text,"
             + "    tx_id               timeuuid, "
             + "    doc_json            text,"
             + "    exist_keys          set<text>,"

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/DeleteOperationTest.java
@@ -65,7 +65,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -142,7 +142,7 @@ public class DeleteOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/FindOperationTest.java
@@ -91,7 +91,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -181,7 +181,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -210,7 +210,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -333,7 +333,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -363,7 +363,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -465,7 +465,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -494,7 +494,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -575,7 +575,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -645,7 +645,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -717,7 +717,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -795,7 +795,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -876,7 +876,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -952,7 +952,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1027,7 +1027,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1107,7 +1107,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1185,7 +1185,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1263,7 +1263,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1339,7 +1339,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1437,7 +1437,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1655,7 +1655,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1854,7 +1854,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2047,7 +2047,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2222,7 +2222,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2295,7 +2295,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2368,7 +2368,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2442,7 +2442,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2525,7 +2525,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2631,7 +2631,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2753,7 +2753,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -2853,7 +2853,7 @@ public class FindOperationTest extends AbstractValidatingStargateBridgeTest {
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationRetryTest.java
@@ -104,7 +104,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -137,7 +137,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -306,7 +306,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -339,7 +339,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -516,7 +516,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -549,7 +549,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -747,7 +747,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -786,7 +786,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -1022,7 +1022,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -1061,7 +1061,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")
@@ -1090,7 +1090,7 @@ public class ReadAndUpdateOperationRetryTest extends AbstractValidatingStargateB
                 List.of(
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("key")
-                        .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                        .setType(TypeSpecs.VARCHAR)
                         .build(),
                     QueryOuterClass.ColumnSpec.newBuilder()
                         .setName("tx_id")

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/ReadAndUpdateOperationTest.java
@@ -130,7 +130,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -263,7 +263,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -385,7 +385,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -569,7 +569,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -701,7 +701,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -851,7 +851,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1038,7 +1038,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1206,7 +1206,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1322,7 +1322,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1443,7 +1443,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1613,7 +1613,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -1728,7 +1728,7 @@ public class ReadAndUpdateOperationTest extends AbstractValidatingStargateBridge
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/operation/model/impl/SerialConsistencyOverrideOperationTest.java
@@ -83,7 +83,7 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")
@@ -255,7 +255,7 @@ public class SerialConsistencyOverrideOperationTest extends AbstractValidatingSt
                   List.of(
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("key")
-                          .setType(TypeSpecs.tuple(TypeSpecs.TINYINT, TypeSpecs.VARCHAR))
+                          .setType(TypeSpecs.VARCHAR)
                           .build(),
                       QueryOuterClass.ColumnSpec.newBuilder()
                           .setName("tx_id")

--- a/src/test/java/io/stargate/sgv2/jsonapi/service/schema/model/JsonapiTableMatcherTest.java
+++ b/src/test/java/io/stargate/sgv2/jsonapi/service/schema/model/JsonapiTableMatcherTest.java
@@ -26,7 +26,7 @@ class JsonapiTableMatcherTest {
                       .setName("key")
                       .setType(
                           QueryOuterClass.TypeSpec.newBuilder()
-                              .setBasic(QueryOuterClass.TypeSpec.Basic.VARCHAR)
+                              .setBasic(QueryOuterClass.TypeSpec.Basic.INT)
                               .build())
                       .build())
               .build();
@@ -112,16 +112,8 @@ class JsonapiTableMatcherTest {
                   .setName("key")
                   .setType(
                       QueryOuterClass.TypeSpec.newBuilder()
-                          .setTuple(
-                              QueryOuterClass.TypeSpec.Tuple.newBuilder()
-                                  .addElements(
-                                      QueryOuterClass.TypeSpec.newBuilder()
-                                          .setBasic(QueryOuterClass.TypeSpec.Basic.TINYINT))
-                                  .addElements(
-                                      QueryOuterClass.TypeSpec.newBuilder()
-                                          .setBasic(QueryOuterClass.TypeSpec.Basic.VARCHAR)
-                                          .build())
-                                  .build()))
+                          .setBasic(QueryOuterClass.TypeSpec.Basic.VARCHAR)
+                          .build())
                   .build());
     }
 


### PR DESCRIPTION
# What

Change `_id` in json api to only support string instead of multiple types. This changes the underlying Cassandra table to use text as primary key instead of tuples. So this version of JSON API works together with Stargate CDC solution which does not support tuples as primary keys.

- Updated cassandra table schema
- Updated inserting of new rows
- Updated finding of existing rows
- Updated unit tests

# Testing

```
./mvnw test
```